### PR TITLE
Add OpenXR-SDK as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "external/Vulkan-Headers"]
 	path = external/Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers.git
+[submodule "external/OpenXR-SDK"]
+	path = external/OpenXR-SDK
+	url = https://github.com/KhronosGroup/OpenXR-SDK.git


### PR DESCRIPTION
Add the OpenXR-SDK as a submodule for the OpenXR headers and the registry (xr.xml) file.

(@bradgrantham-lunarg , just so you're aware.  I did rebase the `openxr_initial_support` branch too which will require you to force pull).